### PR TITLE
:arrow_up: Migrate from twitter HTTP `profile_image_url` to HTTPS URLs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -44,5 +44,5 @@ jobs:
         - name: golangci-lint
           uses: golangci/golangci-lint-action@v2
           with:
-            version: v1.27
+            version: v1.29
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
       steps:
         - uses: actions/checkout@v2
         - name: golangci-lint
-          uses: golangci/golangci-lint-action@v1
+          uses: golangci/golangci-lint-action@v2
           with:
             version: v1.27
 

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -16,7 +16,7 @@ const DefaultImageURL = "https://abs.twimg.com/sticky/default_profile_images/def
 const ShowURL = "https://api.twitter.com/1.1/users/show.json"
 
 type profile struct {
-	ImageURL string `json:"profile_image_url"`
+	ImageURL string `json:"profile_image_url_https"`
 }
 
 func getUserProfileImageURL(username, token string) string {

--- a/twitter/twitter_test.go
+++ b/twitter/twitter_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const imageURL = "http://pbs.twimg.com/profile_images/1180040914695327744/qTSU9ZXI_normal.jpg"
+const imageURL = "https://pbs.twimg.com/profile_images/1180040914695327744/qTSU9ZXI_normal.jpg"
 
 type TwitterSuite struct {
 	suite.Suite
@@ -109,7 +109,7 @@ func (s *TwitterSuite) Test_HandlerUserFound() {
 func (s *TwitterSuite) Test_HandlerUserFoundBigger() {
 	assert := s.Assert()
 	const username = "charlyx"
-	const expectedURL = "http://pbs.twimg.com/profile_images/1180040914695327744/qTSU9ZXI_bigger.jpg"
+	const expectedURL = "https://pbs.twimg.com/profile_images/1180040914695327744/qTSU9ZXI_bigger.jpg"
 	mockTwitterShowAPI(username)
 
 	handlerFunc, _ := NewHandlerFunc(s.secretAccessor)
@@ -127,7 +127,7 @@ func (s *TwitterSuite) Test_HandlerUserFoundBigger() {
 func (s *TwitterSuite) Test_HandlerUserFoundMini() {
 	assert := s.Assert()
 	const username = "charlyx"
-	const expectedURL = "http://pbs.twimg.com/profile_images/1180040914695327744/qTSU9ZXI_mini.jpg"
+	const expectedURL = "https://pbs.twimg.com/profile_images/1180040914695327744/qTSU9ZXI_mini.jpg"
 	mockTwitterShowAPI(username)
 
 	handlerFunc, _ := NewHandlerFunc(s.secretAccessor)
@@ -145,7 +145,7 @@ func (s *TwitterSuite) Test_HandlerUserFoundMini() {
 func (s *TwitterSuite) Test_HandlerUserFoundOriginal() {
 	assert := s.Assert()
 	const username = "charlyx"
-	const expectedURL = "http://pbs.twimg.com/profile_images/1180040914695327744/qTSU9ZXI.jpg"
+	const expectedURL = "https://pbs.twimg.com/profile_images/1180040914695327744/qTSU9ZXI.jpg"
 	mockTwitterShowAPI(username)
 
 	handlerFunc, _ := NewHandlerFunc(s.secretAccessor)
@@ -192,7 +192,7 @@ func (s *secretAccessorMock) Get(key string) (string, error) {
 
 func mockTwitterShowAPI(username string) {
 	query := fmt.Sprintf("screen_name=%s", username)
-	resp := fmt.Sprintf(`{"profile_image_url":"%s"}`, imageURL)
+	resp := fmt.Sprintf(`{"profile_image_url_https":"%s"}`, imageURL)
 
 	httpmock.RegisterResponderWithQuery("GET", ShowURL, query,
 		httpmock.NewStringResponder(http.StatusOK, resp),


### PR DESCRIPTION
`profile_image_url` is deprecated and should replaced by `profile_image_url_https`

See https://developer.twitter.com/en/docs/twitter-api/v1/data-dictionary/object-model/user

Please try locally before approving, I don't have any Twitter API KEY so I couldn't try myself.